### PR TITLE
docs[install/pre-build binaries]: add runtime setup

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -41,9 +41,9 @@ Note that:
 
 ## Pre-built binaries
 
-Download pre-built binaries from the
-[GitHub Releases page](https://github.com/helix-editor/helix/releases). Add the binary to your system's `$PATH` to use it from the command
-line.
+Download pre-built binaries from the [GitHub Releases page](https://github.com/helix-editor/helix/releases). 
+Add the `hx` binary to your system's `$PATH` to use it from the command line, and copy the `runtime` directory into the config directory (for example ~/.config/helix/runtime on Linux/macOS).
+The runtime location can be overriden via the HELIX_RUNTIME environment variable.
 
 ## Linux, macOS, Windows and OpenBSD packaging status
 


### PR DESCRIPTION
Hi,

## Context
I installed my helix by pre-build binary following [the book](https://docs.helix-editor.com/install.html#pre-built-binaries), and the highlight didn't work.
I found [the issue #1098](https://github.com/helix-editor/helix/issues/1098#issuecomment-968564508) with the problem and the solution, and moving the runtime to the correct location the syntax highlight started to work.

## What these issue solve?
These issues update the installation of the pre-build binary docs to add the `runtime` folder information, so people who follow the instructions will have the syntax highlighting working on the first time.

## Other possible implementation
The book explains how to setup the runtime folder [on the building by the source section](https://docs.helix-editor.com/install.html#multiple-runtime-directories), but I didn't find it on the first time because it was too far away and in the build by source section, so I didn't expect do need to follow these steps, but we can also make one session just for the runtime and like both the binary installation and by source to it


